### PR TITLE
update for recent Node versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "pako": "^1.0.0"
   },
   "devDependencies": {
-    "eslint": "^2.3.0",
-    "mocha": "^2.4.5"
+    "eslint": "^7.1.0",
+    "mocha": "^7.2.0"
   }
 }

--- a/ttf2woff.js
+++ b/ttf2woff.js
@@ -68,7 +68,7 @@ if (args.metadata) {
 
 var ttf = new Uint8Array(input);
 //var ttf = Array.prototype.slice.call(input, 0);
-var woff = new Buffer(ttf2woff(ttf, options).buffer);
+var woff = Buffer.from(ttf2woff(ttf, options).buffer);
 
 fs.writeFileSync(args.outfile[0], woff);
 


### PR DESCRIPTION
* Replace `new Buffer` by `Buffer.from`, to remove deprecation warning in Node `>= v6`
* Update dev dependencies, to remove security warnings