### PR TITLE
Make output file name optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,20 @@ Install:
 npm install -g ttf2woff
 ```
 
-Usage example:
+Usage:
+```bash
+ttf2woff [-h] [-v] [-m METADATA] infile [outfile]
+```
 
-``` bash
+Example:
+```bash
 ttf2woff fontello.ttf fontello.woff
 ```
 
+If the outfile name can be deduced from the infile name, it can be omitted
+```bash
+ttf2woff fontello.ttf
+```
 
 Authors
 -------

--- a/ttf2woff.js
+++ b/ttf2woff.js
@@ -31,7 +31,7 @@ parser.addArgument(
 parser.addArgument(
   [ 'outfile' ],
   {
-    nargs: 1,
+    nargs: '?',
     help: 'Output file'
   }
 );
@@ -45,15 +45,28 @@ parser.addArgument(
 );
 
 var args = parser.parseArgs();
+
 var input;
 var options = {};
 
 /* eslint-disable */
 
+var infile = args.infile[0];
+var outfile = args.outfile && args.outfile[0];
+
+if (!outfile) {
+  if (infile.endsWith('.ttf')) {
+    outfile = infile.replace(/\.ttf$/, '.woff');
+  } else {
+    console.error("infile doesn't have a .ttf extension: can't deduce outfile name", outfile);
+    process.exit(1);
+  }
+}
+
 try {
-  input = fs.readFileSync(args.infile[0]);
+  input = fs.readFileSync(infile);
 } catch (e) {
-  console.error("Can't open input file (%s)", args.infile[0]);
+  console.error("Can't open input file (%s)", infile);
   process.exit(1);
 }
 
@@ -70,5 +83,4 @@ var ttf = new Uint8Array(input);
 //var ttf = Array.prototype.slice.call(input, 0);
 var woff = new Buffer(ttf2woff(ttf, options).buffer);
 
-fs.writeFileSync(args.outfile[0], woff);
-
+fs.writeFileSync(outfile, woff);


### PR DESCRIPTION
To be able to just do
```bash
ttf2woff somefont.ttf
```

The main motivation to be that lazy is to easily convert many files at once:
```bash
for f in *.ttf ; do ttf2woff $f ; done
```